### PR TITLE
add a test case of CRLFBlankLine

### DIFF
--- a/multicorecsv_test.go
+++ b/multicorecsv_test.go
@@ -91,6 +91,11 @@ var readTests = []struct {
 		},
 	},
 	{
+		Name:   "CRLFBlankLine",
+		Input:  "a,b\r\n\r\nc,d\r\n",
+		Output: [][]string{{"a", "b"}, {"c", "d"}},
+	},
+	{
 		Name:               "BlankLineFieldCount",
 		Input:              "a,b,c\n\nd,e,f\n\n",
 		UseFieldsPerRecord: true,


### PR DESCRIPTION
Hi @mzimmerman ,

I've found the cause: blank line of `\r\n` will cause error. And a test case is added here.

Sorry for the misleading error message "no data found in file", it was in my code.
