### PR TITLE
Seamless support for reading data with meta line of separator declaration used by MS Excel

### DIFF
--- a/multicorecsv_test.go
+++ b/multicorecsv_test.go
@@ -281,6 +281,12 @@ a,bb,c
 a,bb,c
 `,
 	},
+	{
+		Name:             "DataWithMetaLine",
+		TrimLeadingSpace: true,
+		Input:            "sep=,\na,b,c, ",
+		Output:           [][]string{{"a", "b", "c", ""}},
+	},
 }
 
 func TestRead(t *testing.T) {


### PR DESCRIPTION
This PR adds seamless support for reading data with meta line of separator declaration used by MS Excel.

The original [discussion](https://github.com/shenwei356/csvtk/issues/13). 

Sample data:

```
sep=,
id,first_name,last_name,username
11,"Rob","Pike",rob
2,Ken,Thompson,ken
4,"Robert","Griesemer","gri"
1,"Robert","Thompson","abc"
NA,"Robert","Abel","123
```